### PR TITLE
docs: Code smell audit reports

### DIFF
--- a/reports/code-smells/01-security.md
+++ b/reports/code-smells/01-security.md
@@ -1,0 +1,57 @@
+# 01 — Security Issues (Critical & High)
+
+Consolidated security findings across the whole codebase, for triage. Each item also appears in its area report ([02-backend.md](02-backend.md) / [03-frontend.md](03-frontend.md)) with surrounding context. Verified items are marked ✅ (manually confirmed against source).
+
+---
+
+## Authentication & authorization
+
+- **🔴 `server/apps/uploads/views.py:20,75`** ✅ — `get_presigned_url` and `get_presigned_url_for_post` have **no authentication or permission checks**. Any anonymous caller can mint a presigned `PUT` URL (write arbitrary objects to your R2/S3 bucket) or a presigned `GET` for any post's media. *Fix:* require authentication and authorize per-user/per-post.
+
+- **🔴 `server/apps/blogs/views.py:24`** — `PostViewSet` sets `permission_classes = [AllowAny]` for all actions and hand-rolls `is_author`/`is_admin` checks inside `update()`/`destroy()` (duplicated verbatim). Bypasses DRF's permission framework and is easy to get wrong. *Fix:* an `IsAuthorOrAdmin` permission class per action.
+
+- **🔴 `server/apps/users/management/commands/init_users.py:25`** ✅ — `create_superuser(username='admin', password='admin')` on the `--superuser-only` path leaves a trivially guessable superuser in any environment it's run. *Fix:* require an env/prompt-supplied password; never default to `admin/admin`.
+
+- **🟠 `server/apps/users/management/commands/init_users.py:39`** ✅ — The anonymous user is created via `User.objects.create(username='anonymous')` with **no `set_unusable_password()` and no `is_active=False`**, leaving a login-capable account with an unset password hash. *Fix:* set an unusable password and deactivate login.
+
+- **🟠 `server/apps/auth/views.py:23-24,77-82`** — No rate limiting/throttling on `login`/`signup` (brute-force / credential-stuffing), and `logout` accepts `GET` (state change via a CSRF-unsafe method). *Fix:* add DRF/django-ratelimit throttles; restrict logout to `POST`/`DELETE`.
+
+- **🟠 `server/apps/blogs/views.py:201,217`** — Open `TODO`s: "Restrict access to share only to authorized users" on the media MIME and streaming endpoints — media of any post is currently served to any caller. *Fix:* authorize access before streaming; track as a real issue, not a comment.
+
+## Input validation & injection
+
+- **🔴 `server/apps/uploads/views.py:28`** ✅ — User-supplied `file_name` is concatenated directly into the S3 key (`f'post/audio/{user_id}/{file_name}'`) with no sanitization → path traversal / key injection (`../`) to overwrite arbitrary objects. *Fix:* sanitize/whitelist the filename; derive the key server-side.
+
+- **🔴 `server/apps/uploads/views.py:24-26`** ✅ — `json.loads(request.body)` and `data['content_type']` / `data['file_name']` have no error handling (bad JSON / missing key → 500) and `content_type` is unvalidated (client sets the object's Content-Type freely). *Fix:* validate inputs, whitelist content types, return 400 on bad input.
+
+- **🔴 `server/apps/website/views.py:14-46`** — `local_dev_response_from_file_in_app_public_dir` builds `file_path = 'app/public' + request.path` and opens it directly. Although DEBUG-only, `request.path` is attacker-controlled and unsanitized → path traversal (`/../../`) to read arbitrary files in dev. *Fix:* normalize and confine the resolved path to the public dir.
+
+- **🟠 `server/apps/auth/views.py:30,48`** — `json.loads(request.body)` with no try/except in `login`/`signup` → unhandled `JSONDecodeError` (500) on a malformed body. *Fix:* wrap and return 400.
+
+## Storage / object exposure
+
+- **🔴 `server/config/settings.py:391`** ✅ — `AWS_DEFAULT_ACL = 'public-read'` makes every uploaded object world-readable. *Fix:* default to a private ACL; serve via presigned GET.
+
+- **🔴 `server/config/settings.py:392`** ✅ — `AWS_QUERYSTRING_AUTH = False` strips signed query params from storage URLs, so object URLs are unauthenticated. Combined with `public-read`, all media is fully public. *Fix:* keep objects private and use presigned URLs (or set this `True`).
+
+- **🟠 `server/apps/uploads/views.py:69`** — Presigned GET URLs are valid for **1 hour** (`ExpiresIn=3600`) while the frontend only caches them ~1 minute; over-long exposure on already-public objects. *Fix:* shorten expiry; name the constant.
+
+## Secrets & configuration
+
+- **🔴 `server/config/settings.py:70-101`** — `check_and_create_env_file()` silently auto-generates `.env` with a fresh `SECRET_KEY` if missing. In production a missing env mints a new key each deploy (invalidating all sessions/signatures) and hides misconfiguration. *Fix:* fail fast when required secrets are absent.
+
+- **🔴 `server/config/settings.py`** (no SSL/cookie hardening) — Missing `SECURE_SSL_REDIRECT`, `SECURE_HSTS_SECONDS`, `SECURE_HSTS_INCLUDE_SUBDOMAINS`, `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SECURE_PROXY_SSL_HEADER`, `SECURE_CONTENT_TYPE_NOSNIFF`. Session/CSRF cookies can be sent over HTTP. *Fix:* add these gated on `not DEBUG`.
+
+- **🔴 `server/config/settings.py:218-219`** — `AUTH_PASSWORD_VALIDATORS = []` when `DEBUG` is true disables all password-strength checks; a DEBUG slip in staging accepts weak passwords. *Fix:* don't disable validators wholesale.
+
+- **🟠 `server/config/settings.py:117-128`** — Production `ALLOWED_HOSTS` hardcodes multiple domains **plus** `localhost`/`127.0.0.1`; allowing localhost in prod is a Host-header risk and the domain list is baked into source. *Fix:* drive `ALLOWED_HOSTS` (and the duplicated `CSRF_TRUSTED_ORIGINS`) from one env var.
+
+## Frontend security
+
+- **🔴 `app/src/components/post/Post.tsx:32-38`** ✅ — `FormatText` runs `DOMPurify.sanitize(children)` **first**, then a regex splices the captured `url` into raw `<a href="…">…</a>` HTML rendered via `dangerouslySetInnerHTML`. The post-sanitize URL substring is not re-escaped, partially defeating the sanitizer. *Fix:* build the anchor markup first, then sanitize the final HTML (allow `target`/`rel`), or escape the URL before interpolation.
+
+- **🔴 `app/src/lib/utils/fetch.ts:38-68` + `app/src/hooks/useAuth.tsx:30` + `app/src/lib/api/posts.ts` (several)** — No request sets `credentials: 'include'`, yet the app relies entirely on session cookies + CSRF. If `VITE_SERVER_HOST` is cross-origin, the cookie is never sent and auth/CSRF silently break (and `/auth/status/` reports unauthenticated). *Fix:* add `credentials: 'include'` in `getFetchOptions`, the CSRF fetch, and the bare `fetch`es in `posts.ts`/`useAuth`.
+
+- **🟠 `app/src/lib/utils/fetch.ts:25-34`** — `getCsrfToken` doesn't check `response.ok` and reads `data.token` from untyped JSON; a failed CSRF request caches `undefined` as the token for an hour (every subsequent mutating request 403s with no refetch). *Fix:* validate the response/token and refresh on 403.
+
+- **🟠 `app/src/pages/DebugPage.tsx:4-58`** — A `/debug` route exposing UA internals (incl. non-standard `navigator.userAgentData`) is registered in production routing. *Fix:* gate to dev only.

--- a/reports/code-smells/02-backend.md
+++ b/reports/code-smells/02-backend.md
@@ -1,0 +1,151 @@
+# 02 — Backend (Django)
+
+Findings for `server/`. Security-critical items are cross-referenced in [01-security.md](01-security.md) and marked 🛡️. Severities: 🔴 high · 🟠 medium · 🟡 low.
+
+---
+
+## server/apps/blogs/models.py
+
+- 🔴 **`:37-53`** — `Media.save()` uses fragile multi-save logic (null `file`, `super().save()`, restore `file`, pop `force_insert`, `super().save()` again) to work around needing the PK for the upload path. The second `super().save()` runs even on the insert branch and `force_insert` is never re-applied. *Fix:* extract path-generation clearly or use a `post_save` signal.
+- 🔴 **`:67,79,86,93,100`** — Five `except Exception` blocks that only log and swallow errors during save/delete, masking real failures (disk full, permissions). *Fix:* catch `OSError` specifically; surface/re-raise.
+- 🟠 **`:70-104`** — `Media.delete()` is long with three near-identical try/except blocks for `file`/`mp3_file`/`thumbnail`. *Fix:* `_remove_file(field, label)` helper.
+- 🟠 **`:99`** — `os.rmdir(media_dir)` raises if the dir is non-empty, and `media_dir` is derived only from `self.file`; if `file` is empty but other files exist, the dir leaks. *Fix:* compute dir independently; use guarded cleanup.
+- 🟠 **`:14-15`** — `media_file_path` has no docstring/type hints and depends on `instance.id` which is `None` for new records (the exact edge case `save()` works around). *Fix:* document and type.
+- 🟠 **`:106-114`** — `convert_to_mp3()` calls full `self.save()`, re-triggering the whole complex override + duration extraction, and doesn't validate the conversion produced a file. *Fix:* `save(update_fields=['mp3_file'])` and check output.
+- 🟠 **`:132-141`** — `Post.delete()` manually deletes `self.media` and swallows exceptions; a failed media delete still proceeds, orphaning files. *Fix:* signal-based cleanup or documented cascade.
+- 🟡 **`:18-22`** — `MEDIA_TYPE_CHOICES` are magic strings also referenced by literal in `views.py:292` and duplicated in the frontend. *Fix:* a `TextChoices` enum.
+- 🟡 **`:31`** — `media_type = CharField(max_length=255)` — 255 is excessive for a 3-value choice (copy-paste magic number across fields).
+- 🟡 **`:11`** — Logger named with the hardcoded string `'server.apps.blogs'` while `views.py` uses `__name__`; inconsistent.
+
+## server/apps/blogs/views.py
+
+- 🔴 **`:200,216,219`** — `Post.objects.get(...)` raises unhandled `DoesNotExist` (500) instead of 404 in `get_post_media_mime_type`/`stream_post_media`. *Fix:* `get_object_or_404`.
+- 🔴 **`:219-250`** — `stream_post_media` dereferences `post.media.file.path` with no `post.media is not None` check (→ `AttributeError`/500) and no path-existence validation before `os.path.getsize`. *Fix:* guard for missing media.
+- 🔴 **`:231-233,254,262-273`** — DRF `Response(...)` returned from plain Django views (no renderer context → error, not the intended 400/JSON), and `FileResponse(data, ...)` at :254 passes raw `bytes` instead of a file-like object. *Fix:* use `JsonResponse`/`HttpResponse` in non-DRF views; pass a stream to `FileResponse`.
+- 🔴 **`:42-79`** 🛡️ — `create()` is long and mixes request munging, debug printing, media creation, and re-serialization; it forces `Media.pk == Post.pk` (`id=serializer.instance.id`), a hidden, undocumented coupling between unrelated tables. *Fix:* separate concerns; don't pin PKs.
+- 🟠 **`:54-61,126`** — Debug via `print()` with an inline `import json` (and a stray `print(f'Media updates: …')` in `update()`). *Fix:* `logger.debug`; move imports to top.
+- 🟠 **`:81-129,171-194`** 🛡️ — Author/admin authorization duplicated verbatim between `update()` and `destroy()`. *Fix:* permission class / helper.
+- 🟠 **`:25-27`** — `queryset = Post.objects.all()` with no `select_related('author','media')` → N+1 in list/retrieve (serializer touches `author`/`media` per post). TODO at :26 acknowledges it. *Fix:* add `select_related`/`prefetch_related`.
+- 🟠 **`:143-156`** — `transcribe` inlines mp3-conversion logic that duplicates `Media.convert_to_mp3()` and re-checks `.endswith('.mp3')` twice. *Fix:* move to model/service.
+- 🟠 **`:235`** — Magic condition `ranges.ranges[0][1] == 2` (range-end of exactly 2 → "whole file") is unexplained and likely a bug. *Fix:* document/replace.
+- 🟡 **`:222`** — `request.META.get('HTTPS_RANGE')` is not a real WSGI var (range is always `HTTP_RANGE`); the `is_secure()` branch is dead/incorrect.
+- 🟡 **`:243`** — `start, end = ranges[0]` indexes the `Range` object inconsistently with `ranges.ranges[0]` used elsewhere; the broad `except` then hides any error.
+
+## server/apps/blogs/serializers.py
+
+- 🟠 **`:32,45`** — `PostSerializer` is `HyperlinkedModelSerializer` with no hyperlinked relations, and includes the reverse `post_set` with no `prefetch_related` → N+1 when listing posts with replies. *Fix:* prefetch or drop the reverse field.
+- 🟠 **`:15-29`** — `MediaSerializer` exposes raw `file`/`mp3_file` storage paths to clients, leaking storage structure. *Fix:* expose only signed/derived URLs.
+- 🟡 **`:49-56`** — `PostCreateSerializer` declares a writable `media` FK field, but `create()` strips `media` before validation and creates Media separately → the field is dead/misleading.
+
+## server/apps/blogs/transcription.py
+
+- 🔴 **`:25-46`** — Temp-file leak: `os.unlink(temp_file.name)` is only on the success path; if `transcriptions.create` raises, the `delete=False` temp file is never removed. *Fix:* `try/finally`.
+- 🟠 **`:22`** — Mutating module-global `openai.api_key` per call is not thread-safe and uses the deprecated pattern. *Fix:* instantiate a local `OpenAI(api_key=…)` client.
+- 🟠 **`:12,29`** — `audio_file` is untyped; copying a local `FieldFile` via `.chunks()` into a temp file is redundant (the file already exists on disk in local-storage mode); no handling when `OPENAI_API_KEY` is unset. *Fix:* type it, reuse the existing path, guard the key.
+- 🟡 **`:34-46`** — Three-level nesting (`NamedTemporaryFile` → `with open` → API/unlink/return). *Fix:* flatten.
+
+## server/apps/blogs/utils/convert_to_mp3.py
+
+- 🔴 **`:42-50`** 🛡️ ✅ — `CalledProcessError` is caught, logged, and the function **still returns `output_file` as if successful**; callers then use a non-existent file. *Fix:* re-raise or return a success flag.
+- 🟠 **`:28`** — `# TODO: Handle case when file already exists` — ffmpeg without `-y` hangs on stdin waiting for overwrite confirmation if output exists, deadlocking the request. *Fix:* add `-y` or pre-check.
+- 🟡 **`:34-38`** — Bitrate `96k`, sample rate `44100`, channels `2` are unexplained magic numbers.
+- 🟡 **`:16-21`** — Docstring missing a `Returns:` section (Google convention).
+
+## server/apps/blogs/utils/get_file_mimetype.py
+
+- 🔴 **`:9-19`** 🛡️ — `subprocess.run` without `check=True`: a failing `file` command still has its `stdout` read, returning empty/garbage MIME silently; no check that `file_path` exists. *Fix:* `check=True`, validate input.
+- 🟠 **`:20-22`** — Bare `except Exception` returns the magic string `'unknown'`, which callers then pass as an (invalid) Content-Type. *Fix:* narrow exceptions; signal failure.
+- 🟡 **`:7`** — No type hints / docstring, unlike sibling `media.py`.
+
+## server/apps/blogs/utils/media.py
+
+- 🟠 **`:31-33`** — `except Exception` returns `None`, masking programming errors (e.g. `ValueError` from `float('')`). *Fix:* catch `(subprocess.CalledProcessError, ValueError)`.
+- 🟡 **`:9`** — `Optional[timedelta]` (older style); project targets 3.13 where `timedelta | None` is idiomatic.
+
+## server/apps/blogs/utils/__init__.py
+
+- 🟡 **`:1-4`** — `get_file_mime_type` isn't re-exported while `convert_to_mp3`/`get_media_duration` are, so imports of it use the full path elsewhere — inconsistent surface.
+
+## server/apps/blogs/admin.py
+
+- 🟠 **`:23-46`** — `list_display` includes `get_media_type`/`get_media_duration` which dereference `obj.media` per row → N+1 in the changelist. *Fix:* `list_select_related = ('media','author')`.
+- 🟡 **`:38-46`** — Old `func.short_description = …` pattern instead of `@admin.display(description=…)` (avoids the pyright-ignores at :41,:46).
+
+## server/apps/blogs/apps.py
+
+- 🟡 **`:1-6`** — No `ready()`; the file-cleanup/duration logic in model overrides would be more robust as signals registered here. (Architectural note.)
+
+## server/config/settings.py
+
+- 🔴 **`:391-392`** 🛡️ ✅ — `AWS_DEFAULT_ACL='public-read'` + `AWS_QUERYSTRING_AUTH=False` → all media public & URLs unauthenticated.
+- 🔴 **`:117-128`** 🛡️ — `ALLOWED_HOSTS` hardcodes multiple domains plus localhost (Host-header risk; env-drive it).
+- 🔴 **`:218-219`** 🛡️ — Empty `AUTH_PASSWORD_VALIDATORS` under DEBUG.
+- 🔴 **`:70-101`** 🛡️ — `check_and_create_env_file()` fabricates a fresh `SECRET_KEY`; fail fast instead.
+- 🔴 **(file)** 🛡️ — Missing production SSL/cookie/HSTS/nosniff headers.
+- 🟠 **`:383-397,508`** — S3/R2/OpenAI config read via raw `os.getenv` while the rest uses `environs` `env(...)`; missing keys silently become `None`. *Fix:* `env.str(..., default=...)` consistently + validate.
+- 🟠 **`:388`** — `AWS_S3_ENDPOINT_URL = f"https://{os.getenv('R2_ACCOUNT_ID')}.{os.getenv('R2_ENDPOINT_DOMAIN')}"` builds `https://None.None` when unset. *Fix:* validate presence first.
+- 🟠 **`:24-60` vs `256-333`** — `LOGGING` is defined and `dictConfig`'d early, then fully overwritten (`copy.deepcopy(DEFAULT_LOGGING)`) and reassigned at :333; the early config is dead/wasted. *Fix:* one LOGGING definition.
+- 🟠 **`:258,266`** — `import copy` / `import os` placed mid-file/inside a function (`os` already imported at top). *Fix:* move to top.
+- 🟠 **`:147-149`** — Dev-only apps (`django_extensions`, `whitenoise.runserver_nostatic`) shipped to prod unconditionally. *Fix:* gate on DEBUG.
+- 🟠 **`:353-374`** — `CORS_ALLOWED_ORIGINS` hardcodes `127.0.0.1:8000` (+ commented dead line) and `CSRF_TRUSTED_ORIGINS` duplicates the prod domain list. *Fix:* one env-driven source.
+- 🟡 **`:306`** — Magic `10485760`; use `10 * 1024 * 1024`.
+- 🟡 **`:265,272`** — Param `logging` shadows the stdlib module; `os.mkdir` should be `os.makedirs(exist_ok=True)`.
+- 🟡 **`:281-297`** — Large commented-out dead symlink code.
+- 🟡 **`:413-414`** — `os.makedirs(MEDIA_ROOT)` without `exist_ok=True` (race-prone).
+- 🟡 **`:463-485`** — Hardcoded CSP hash magic strings with no traceability to their source template.
+- 🟡 **`:4-10,107`** — Stale comments referencing Django 3.2.2 / 5.1 (project is 5.2.5).
+
+## server/config/urls.py
+
+- 🟠 **`:60,70`** — Catch-all `re_path('', index)` swallows unmatched API paths and returns HTML to API clients, masking 404s. *Fix:* stricter pattern / explicit prefixes.
+- 🟡 **`:64-65`** — Media served via `static()` only under DEBUG; local-storage media in production 404s silently. *Fix:* document/handle the non-S3 prod case.
+
+## server/apps/auth/views.py
+
+- 🟠 **`:23-24,77-82`** 🛡️ — No throttling on login/signup; `logout` accepts `GET`.
+- 🟠 **`:30,48`** 🛡️ — `json.loads(request.body)` with no try/except → 500 on bad JSON.
+- 🟠 **`:42`** — `login` returns `JsonResponse(user_id, safe=False)` — a bare integer, inconsistent with object responses elsewhere. *Fix:* `{'user_id': …}`.
+- 🟠 **`:7-8`** — `validate_password`/`ValidationError` imported but unused (dead). *Fix:* remove or actually validate.
+- 🟡 **`:23,85`** — `csrf`/`status` lack docstrings.
+- 🟡 **`:11,77`** — Double-quote string drift vs single-quote convention.
+- 🟡 **(all)** — No type hints on view functions.
+
+## server/apps/uploads/views.py
+
+- 🔴 **`:20,75`** 🛡️ ✅ — No auth on presigned-URL endpoints.
+- 🔴 **`:28`** 🛡️ ✅ — Path traversal via unsanitized `file_name` in the S3 key.
+- 🔴 **`:24-26`** 🛡️ ✅ — No error handling / content-type validation on the JSON body.
+- 🔴 **`:28`** 🛡️ — Hardcoded anonymous fallback `user_id = … else 2`. *Fix:* named setting; resolve the anonymous user explicitly.
+- 🟠 **`:76`** — `Post.objects.get(id=post_id)` with no `DoesNotExist` handling and no per-post authorization. *Fix:* `get_object_or_404` + authorize.
+- 🟠 **`:20-21,56-57`** — Manual `if request.method == 'POST'` / 405 instead of `@require_POST`. *Fix:* use the decorator.
+- 🟠 **`:69`** 🛡️ — 1-hour presigned GET expiry vs ~1-minute frontend cache; over-exposed.
+- 🟡 **`:22`** — `import json` inside the function body.
+- 🟡 **`:34-40`** — `file_name.rsplit('.', 1)[1]` IndexErrors on extensionless names; extension-splitting duplicated.
+- 🟡 **`:62,71`** — Dead `TODO`s about caching signed URLs.
+- 🟡 **(all)** — No type hints/docstrings.
+
+## server/apps/website/views.py
+
+- 🔴 **`:14-46`** 🛡️ — Dev path-traversal via unsanitized `request.path` (see 01-security).
+- 🟠 **`:26-38`** — `get_content_response_type_for_file` returns `None` for unknown extensions (→ `content_type=None`) and `filename.rsplit('.',1)[1]` IndexErrors on dotfiles. *Fix:* use `mimetypes`; guard the split.
+- 🟡 **`:14-21`** — Implicit `return` (None) branch relied on by a walrus; imports inside the function body; no docstrings/type hints.
+
+## server/apps/users/management/commands/init_users.py
+
+- 🔴 **`:25`** 🛡️ ✅ — Hardcoded `admin/admin` superuser.
+- 🟠 **`:39`** 🛡️ ✅ — Anonymous user has no `set_unusable_password()` / `is_active=False`.
+- 🟠 **`:17-22,32`** — State inferred from magic counts (`>= 2`, `== 0`) rather than checking for the specific admin/anonymous usernames; fragile if other users exist.
+- 🟡 **`:22,29`** — Mixes `sys.exit()` and bare `exit()` (a REPL builtin); a command should `return`/raise `CommandError`.
+- 🟡 **`:4,33-34`** — Imports `CommandError` but never uses it; reads creds via `input()`/`getpass()` instead of command args (blocks non-interactive use).
+
+## Empty / boilerplate files (dead code)
+
+- 🟡 **`server/apps/auth/models.py:1-3`** — Only imports `models`; nothing defined.
+- 🟡 **`server/apps/users/views.py:1-3`** — Only imports `render`; nothing defined.
+- 🟡 **`server/apps/users/models.py:5-6`** — `class User(AbstractUser): pass` with no docstring.
+
+## Cross-cutting (backend)
+
+- 🟠 **App registration** — `settings.py` `INSTALLED_APPS` registers `apps.users/website/blogs` but **not** `apps.auth`/`apps.uploads`, whose views are imported in `urls.py`. Relying on importable-but-unregistered apps means no app config/migrations/checks. *Fix:* register all apps.
+- 🟠 **`ANONYMOUS_USER_ID = 2`** is a magic number duplicated in `views.py:perform_create` and `uploads/views.py:28`. *Fix:* a single setting/constant.
+- 🟡 **Logging inconsistency** — f-strings in log calls (models/views/utils) vs lazy `%s` formatting (`transcription.py`, `convert_to_mp3.py`); Django/ruff prefer `%s`.

--- a/reports/code-smells/03-frontend.md
+++ b/reports/code-smells/03-frontend.md
@@ -1,0 +1,267 @@
+# 03 — Frontend (React / TypeScript)
+
+Findings for `app/src/` (excluding vendored `components/ui/`). Security items cross-referenced in [01-security.md](01-security.md), marked 🛡️. Severities: 🔴 high · 🟠 medium · 🟡 low.
+
+---
+
+## Post components
+
+### components/post/Post.tsx
+- 🔴 **`:32-44`** 🛡️ ✅ — `FormatText` sanitizes, then a regex re-injects the captured URL into raw anchor HTML rendered via `dangerouslySetInnerHTML`; the post-sanitize URL is not re-escaped. *Fix:* sanitize the final HTML.
+- 🟠 **`:47-66`** — `Post` is not `React.memo`'d and recomputes `mediaUrl`/`mimeType`/`mediaDuration` every render; in a long feed this re-runs `getMediaUrl`/`getMimeTypeFromPath`/`parseDurationString` per post on any parent update. *Fix:* memoize.
+- 🟠 **`:28-45`** — `FormatText` does sanitize+regex work every render with no memoization. *Fix:* `useMemo` on `children`.
+- 🟡 **`:103`** — `<img alt={mediaAltText}>` may be `undefined` → no alt attribute. *Fix:* fallback `''`.
+- 🟡 **`:7`** — Relative import `'../../types/post'` while the rest uses the `@/` alias.
+
+### components/post/create/CreatePost.tsx
+- 🔴 **(whole file, 359 lines)** — God component: 11 `useState`/`useRef`, five file handlers, a 70-line `handleSubmit`. *Fix:* extract a `useCreatePostMedia` hook + split submit.
+- 🔴 **`:201-202`** — Silent catch: generic `toast.error('Failed to create post')`, never logs the real `error`. *Fix:* log it.
+- 🔴 **`:50,124-131,140`** — Six mutually-exclusive media states (`audioBlob`/`videoBlob`/`audioFile`/`videoFile`/`imageFile` + `mediaType`); `hasNoMedia` and the submit guard re-derive the same 5-term boolean. *Fix:* one discriminated-union state.
+- 🟠 **`:75-122`** — `handleAudioFileChange`/`handleUploadFileChange`/`handleImageFileChange` duplicate the same read/validate/set/toast pattern. *Fix:* one parametrized handler.
+- 🟠 **`:56,153`** — Forged synthetic event `handleSubmit({ preventDefault(){} } as React.FormEvent)`. *Fix:* decouple submit from the event.
+- 🟠 **`:340-352,250,260`** — Inline arrow/JSX callbacks recreated every render over a large subtree → avoidable modal re-renders. *Fix:* memoize handlers.
+- 🟠 **`:288-301`** — `audioInputRef` is rendered but no button triggers it (the Upload button uses `uploadInputRef`); likely dead input/handler. *Verify and remove.*
+- 🟡 **`:18,42`** — `useState<SubmitStatus | ''>` redundantly adds `| ''` (already in `SubmitStatus`).
+- 🟡 **`:160,165,177`** — `recording_${Date.now()}` filename construction duplicated 3×.
+- 🟡 **`:93-95`** — `// TODO: Detect audio vs video` — `.webm` is always treated as audio, mis-categorizing webm video.
+
+### components/post/create/AudioRecorder.tsx
+- 🔴 **`:144,148,160`** ✅ — `console.log` debug statements inside per-sample normalization loops, shipped to prod. *Fix:* remove.
+- 🔴 **`:179-182`** — `normalizeAudio` swallows errors (only `console.error`, returns original blob); failures invisible to the user. *Fix:* surface.
+- 🔴 **`:218-222`** — `useEffect([autoStart, status])` calls `startRecording()` when `status==='idle'`; after reset returns to idle it can auto-restart; `startRecording` not in deps (stale closure). *Fix:* one-shot ref.
+- 🔴 **`:120-122`** 🛡️ — `new AudioContext()` never `close()`d → leaks contexts across recordings. *Fix:* close in `finally`.
+- 🟠 **`:286-320,357`** — If unmounted mid-recording without `stopRecording`, `getUserMedia` tracks are never stopped (mic stays on). *Fix:* stop `stream` tracks in `reset` before nulling.
+- 🟠 **`:363-368`** — `biome-ignore useExhaustiveDependencies` with no justification on unmount cleanup that closes over `audioURL` (may revoke a stale URL). *Fix:* ref.
+- 🟠 **`:370-375`** — `useImperativeHandle` with no deps array; handle + callbacks recreated each render. *Fix:* `useCallback` + deps.
+- 🟡 **`:57-61`** — `formatTime` duplicated (see VideoRecorder/MediaPlayer).
+- 🟡 **`:147,299,327`** — Magic numbers `0.8` (peak), `500` (delays).
+- 🟡 **`:18,201`** — `React.FC` vs the React-19 `ref`-prop style in the same file; inconsistent.
+
+### components/post/create/VideoRecorder.tsx
+- 🔴 **`:68-72`** — `useEffect([autoStart,isRecording,videoURL])` calls `startRecording()` (not in deps); can re-trigger after `reset()`. *Fix:* one-shot guard ref.
+- 🔴 **`:105-117`** 🛡️ — `handleFileChange` creates an object URL stored in `videoURL`; picking a second file overwrites the first without `revokeObjectURL` → leak. *Fix:* revoke previous first.
+- 🔴 **`:190-205`** — `onstop` async IIFE has no try/catch; if `fixWebmDuration` throws, cleanup at :201-203 never runs. *Fix:* try/catch.
+- 🟠 **`:131-135`** — `stopTimer()` doesn't null `timerRef.current` (unlike AudioRecorder). *Fix:* reset the ref.
+- 🟠 **`:172-174`** — `videoRef.current.play().catch(…)` only logs. *Fix:* decide handling.
+- 🟠 **`:153-179`** — Magic bitrate `2500000`/`1000000` and resolution literals. *Fix:* named presets.
+- 🟡 **`:43-47`** — `formatTime` duplicated.
+- 🟡 **`:49-56,101-103`** — `forwardRef` (vs the `ref`-prop style elsewhere); `useImperativeHandle` with no deps array.
+
+### components/post/create/MediaPreview.tsx
+- 🔴 **`:38-75`** 🛡️ — Object-URL effect only returns cleanup inside `if (source)` branches; switching media types leaves stale URLs in state un-reset/un-revoked. *Fix:* reset on every branch transition.
+- 🔴 **`:157-161`** — `document.querySelectorAll('audio')` to pause others reaches outside the React tree. *Fix:* coordinate via context/state.
+- 🟠 **`:90-183`** — Reimplements a full audio player (play/pause/seek/progress/error-map/time-format) duplicating `MediaPlayer.tsx` almost verbatim. *Fix:* reuse `AudioPlayer`.
+- 🟠 **`:95,106,165`** — Magic `0.1` duration buffer, `50`ms interval (duplicated from MediaPlayer).
+- 🟡 **`:265-269`** — `<img alt={imageFile.name}>` uses a filename as alt text.
+
+### components/post/MediaPlayer.tsx
+- 🔴 **`:194-222,438-466`** 🛡️ — `loadAudio`/`loadVideo` `createObjectURL` but never `revokeObjectURL` (cleanup only `removeAttribute('src')`) → leak per play/reload. *Fix:* track & revoke.
+- 🔴 **`:116`** — `width: ${(currentTime/duration)*100}%` is `NaN%` when `duration===0`. *Fix:* guard zero.
+- 🔴 **`:298,517`** — `document.querySelectorAll('audio'|'video')` global pause hack (duplicated). *Fix:* centralize.
+- 🟠 **`:9`** — `RefObject<HTMLAudioElement>` prop type vs callers' `useRef<… | null>(null)`; inaccurate type. *Fix:* `RefObject<… | null>`.
+- 🟠 **`:282-324`** — Convoluted Firefox-autoplay workaround calling `loadAudio()` in two branches (its own TODO at :291). *Fix:* simplify.
+- 🟠 **(whole file, 602 lines)** — `AudioControls`/`AudioPlayer`/`VideoPlayer` share massively duplicated `handleError` switches, blob-fetch `loadX`, reset effects, try-again buttons. *Fix:* shared media-loading hook.
+- 🟠 **`:148,418`** — `biome-ignore useExhaustiveDependencies` omits `initialDuration`; duration won't reset if it changes alone.
+- 🟡 **`:125-129,399-403`** — `mimeType` prop declared but never used (dead prop).
+- 🟡 **`:17-21`** — `formatTime` here is `m:ss` while recorders use `mm:ss`; inconsistent + duplicated.
+- 🟡 **`:251-262,311`** — `handleTimeUpdate` in a 50ms interval captures a stale `duration` closure.
+
+### components/post/EditPostModal.tsx
+- 🔴 **`:42-47`** — `useEffect([post])` mirrors all of `post` into local state; any new `post` object identity from a parent re-render resets in-progress edits. *Fix:* key by `post.id` (remount) or reset only on open.
+- 🟠 **`:49-60`** — `handleSubmit` catches, `console.error`s, and swallows — no user-facing toast on save failure. *Fix:* error UI.
+- 🟡 **`:63-70`** — `handleKeyDown` attached to both `<form>` and each input → fires twice (bubbles). *Fix:* attach once.
+
+### components/post/PostActions.tsx
+- 🟠 **`:43-48`** — `navigator.clipboard.writeText(body)` not awaited / no error handling; shows success toast even on rejection. *Fix:* await + catch.
+- 🟡 **`:5`** — Imports `toast` from `'sonner'` directly vs the app's `'@/components/ui/sonner'` wrapper elsewhere.
+- 🟡 **`:58-71`** — Duplicate likes spans (responsive split renders identical value); Comment/Share buttons are non-functional placeholders with magic `0`.
+
+### components/post/PostHeader.tsx
+- 🟠 **`:19-26`** — `handleCopyLink` success path is only a `// You could add a toast` comment — silent UX. *Fix:* toast.
+- 🟡 **`:37-38`** — `first_name[0]`/`last_name[0]` throws/renders `undefined` on empty names.
+- 🟡 **`:48-73`** — `DropdownMenu` nested inside `TooltipTrigger`/`Tooltip` — fragile composition / a11y-focus conflict.
+
+### components/post/PostMenu.tsx
+- 🟡 **`:33-34`** — `canDelete`/`canEdit` are the identical expression. *Fix:* one `canModify`.
+- 🟡 **`:42-45`** — `handleConfirmDelete` doesn't await `onDelete`; dialog closes with no error feedback on failure.
+- 🟡 **`:51-59`** — `handleDownload` re-derives filename inline (duplicated with Post.tsx:51) with no error handling.
+
+### components/post/DeleteConfirmationDialog.tsx
+- 🟡 **`:37-42`** — Hardcoded destructive styling inline instead of `variant="destructive"`; risks design-system drift.
+- 🟡 **`:38`** — `onConfirm` doesn't close the dialog; closing is an implicit parent contract.
+
+### Likely-dead create components
+- 🟡 **`AudioPostTab.tsx`, `VideoPostTab.tsx`, `TextPostTab.tsx`** appear unreferenced by `CreatePost.tsx` (which uses the `*Modal` variants). They also carry the forged-event `onSubmit: (e: React.MouseEvent)` smell. *Verify usage, then remove.* `AudioPostTab.tsx:43-58` additionally busy-polls `getStatus()` via `setInterval(…, 100)` to bridge an imperative ref — replace with a completion callback if kept.
+
+---
+
+## App-level components & pages
+
+### App.tsx / main.tsx
+- 🟠 **`App.tsx:15`** — `new QueryClient()` with no `defaultOptions` (implicit cache/refetch defaults). *Fix:* explicit `defaultOptions`.
+- 🟡 **`App.tsx:17-38`** — No error boundary; any render error blanks the whole app.
+- 🟡 **`main.tsx:1-5`** — Not wrapped in `<StrictMode>` (would surface the effect bugs above); non-null `getElementById('root')!` with no fallback.
+
+### components/Feed.tsx
+- 🟠 **`:49-52`** — `handleLike` is a stub that only `console.log`s with a TODO. *Fix:* remove/implement.
+- 🟠 **`:70-88`** — `handleEditPost` is `async` with try/catch but doesn't `await editPost(...)`; rejections escape and the success toast fires on failure. *Fix:* await.
+- 🟡 **`:78-81`** — Dead `posts.find`/`throw` guard (immediately swallowed, `post` unused).
+- 🟡 **`:41-47`** — `handlePostCreated` only `console.error`s — no user feedback (inconsistent with delete/edit).
+- 🟡 **`:32-60`** — Only `handleAddFilters` is `useCallback`'d; other child handlers recreated each render, defeating `Post` memoization.
+- 🟡 **`:104-105`** — Redundant inline wrapper `onMatchModeChange`; inline `.map()` array breaks referential stability.
+- 🟡 **`:144-145`** — Magic spacer `<div className="h-96">`.
+- 🟡 **`:44,64,84`** — Catch `error` shadows the outer `usePosts` `error`.
+
+### components/feed/FilterControls.tsx
+- 🔴 **`:57-71`** ✅ — Event-listener leak: `addEventListener` and `removeEventListener` use **different** anonymous functions, so the `keyup` listener is never removed; also queries the DOM by id. *Fix:* one stored handler ref + a React `ref`.
+- 🟠 **`:58`** — `document.getElementById(...) as HTMLInputElement` reaches into the DOM and casts (may not exist on first run). *Fix:* `useRef`.
+- 🟠 **`:79`** — Magic `setTimeout(resolve, 300)` to "wait for scroll" — brittle timing hack.
+- 🟡 **`:42-55,73-80`** — Mixed derived-state-in-ref with effect deps; `async` early-return.
+
+### components/feed/TagFilterPopover.tsx
+- 🟠 **`:151-161`** — `onOpenChange` runs a floating async IIFE (unhandled rejection; state updates after `await` with no unmount guard). *Fix:* proper async handler.
+- 🟠 **`:101-109`** — Convoluted early-return submit condition. *Fix:* simplify/comment.
+- 🟡 **`:178-180` vs `:127-146`** — Trigger count uses raw `selectedTags.length` while the body uses normalized tags; counts disagree on dupes.
+- 🟡 **`:186,217`** — Scattered magic width/height strings.
+- 🟡 **(whole, ~290 lines)** — Oversized; mixes fetching, normalization, pending state, dual mobile/desktop render. *Fix:* split.
+
+### components/feed/ActiveFiltersList.tsx
+- 🟡 **`:43,56`** — Inline arrows per chip per render. *Fix:* extract `FilterChip`.
+- 🟡 **`:36-70`** — Absolute-positioned remove button coupled to magic padding/size values.
+
+### components/GroundRulesModal.tsx
+- 🟠 **`:16-21`** — `React.ReactNode` used but `React` not imported (relies on global types; fragile under `isolatedModules`). *Fix:* import the type.
+- 🟠 **`:85`** — `onOpenChange={setIsOpen}` lets the user dismiss the "mandatory" rules without accepting. *Fix:* prevent close until accepted.
+- 🟡 **`:56-75`** — Acceptance stored as a serialized array but only existence is read back (dead data); `localStorage` access without try/catch.
+- 🟡 **`:103-128`** — Hardcoded `bg-gray-*`/`bg-green-600`/`text-red-500` bypass theme tokens; "I Accept" only *looks* disabled (no real `disabled`/`aria-disabled`).
+
+### components/LoginModal.tsx & SignupModal.tsx
+- 🟠 **`LoginModal:50`** — `await response.json()` on the error path with no try/catch (non-JSON 500 throws, masking the real failure). *Fix:* guard the parse.
+- 🟠 **`SignupModal:60-71`** — Field errors are recovered by `JSON.parse(error.message)` — encoding structured errors inside an `Error.message` string is an anti-pattern. *Fix:* throw typed errors from the API client.
+- 🟡 **Both** — Near-duplicate dialog scaffold, mobile-autofocus workaround (with a redundant `if (isMobile){…return}`), and error-to-form mapping. *Fix:* shared `AuthModal`. Untyped (`any`) parsed error payloads indexed as `errors.form[0]`. No client-side `password1===password2` check.
+
+### components/Navbar.tsx
+- 🟠 **`:58,123`** — Hardcoded GitHub URL duplicated in two places. *Fix:* a constant.
+- 🟡 **`:42-172`** — Desktop nav and mobile dropdown duplicate the entire nav-item list. *Fix:* drive both from one config array.
+- 🟡 **`:35`** — App name `"EchoSphere"` hardcoded (vs "webframework" elsewhere); no single source of truth.
+- 🟡 **`:151,162`** — `text-black dark:text-white` literals bypass theme tokens.
+- 🟡 **`:21-28`** — `handleLogout` swallows errors (only `console.error`).
+
+### components/Profile.tsx
+- 🔴 **`:14-60`** — Entire profile is hardcoded mock data ("John Doe", "248 Following", external sample media, `username='user1'`) shipping to `/profile` with no real data source. *Fix:* wire to API or gate behind a flag.
+- 🟠 **`:15-60`** — The `posts` array and `new Date(Date.now()-…)` rebuild every render → "days ago" drifts, breaks memo stability. *Fix:* move out / `useMemo`.
+- 🟠 **`:62-70`** — `handleLike`/`handleDelete` are `console.log` stubs.
+- 🟡 **`:83,118-122`** — `username[0]` latent crash on empty string; `<Link to="#">` dead nav; hardcoded external URLs.
+
+### components/PullToRefresh.tsx
+- 🟠 **`:32-118`** — Touch-listener effect depends on `onRefresh`; an inline parent callback tears down/re-adds all four listeners every render. *Fix:* memoize/ref the callback.
+- 🟡 **`:90-94`** — Default refresh does a full `window.location.reload()` (loses SPA state). *Fix:* prefer query invalidation.
+- 🟡 **`:78,123-160`** — Imperative DOM style/class mutation; `transitionend` `once` listener can stack; magic numbers.
+
+### components/settings/SettingsPage.tsx
+- 🟠 **`:13-15`** — `useEffect` persists settings on every change **including initial mount**, writing just-read defaults back. *Fix:* skip initial write or persist in the change handlers.
+- 🟠 **`:10-11`** — `getSettings()` called twice to seed two `useState` initializers (reads storage twice). *Fix:* single lazy init.
+- 🟡 **`:57`** — `value as 'low' | 'high'` casts an untyped `RadioGroup` string.
+- 🟡 **`:9-83`** — Local state mirrors persisted settings instead of deriving from one source. *Fix:* a `useSettings` hook.
+
+### components/ThemeProvider.tsx
+- 🟠 **`:65-71`** — `useTheme`'s `if (context === undefined)` guard can **never** fire because the context default is non-undefined; using it outside a provider silently returns the no-op default. *Fix:* default the context to `undefined`.
+- 🟠 **`:33-47`** — System-theme effect reads `matchMedia` once but never subscribes to `change`; OS theme switches at runtime don't update. *Fix:* add a change listener + cleanup.
+- 🟡 **`:49-55`** — `value` object recreated every render → all consumers re-render. *Fix:* `useMemo`.
+- 🟡 **`:29-31,51`** — `localStorage.getItem(...) as Theme` unvalidated; inner `setTheme` shadows the state setter.
+
+### components/ThemeToggle.tsx
+- 🟡 **`:25-39`** — Three near-identical `DropdownMenuItem`s; could be data-driven.
+
+### pages/
+- 🟠 **`DebugPage.tsx:5`** 🛡️ — `MediaRecorder.isTypeSupported` called at render with no guard for environments where `MediaRecorder` is undefined → throws/blanks the page; the `/debug` route also ships to prod.
+- 🟠 **`NotFound.tsx:8`** — `console.error('404 Error: …')` on every 404 render spams prod consoles for normal mistyped URLs. *Fix:* remove.
+- 🟡 **`NotFound.tsx:12-19`** — Raw `<a href="/">` (full reload) instead of `<Link>`; hardcoded `bg-gray-*`/`text-blue-500` won't respect dark mode.
+- 🟡 **`ProfilePage.tsx:1-17`** — Duplicates the page shell found in `Index.tsx`/`SettingsPage.tsx` (3 copies). *Fix:* a shared `PageLayout`.
+- ✅ **`Index.tsx`** — Clean.
+
+---
+
+## Hooks
+
+### hooks/useAuth.tsx
+- 🔴 **`:42,51,28`** — `checkAuthStatus` depends on `authState.isAuthenticated`, so its identity changes on every auth flip and the `useEffect([checkAuthStatus])` re-fetches each change (risk of an extra round-trip/loop). *Fix:* functional `setAuthState(prev => …)`, drop the dep.
+- 🟠 **`:30`** 🛡️ — `/auth/status/` fetch omits `credentials: 'include'`. *Fix:* add it.
+- 🟠 **`:32,48-50`** — `data` from `response.json()` is implicit `any`; on error the state is left stale with only a log. *Fix:* type it; reset/expose error.
+- 🟡 **`:19`** — `React.FC` typing without importing `React`.
+
+### hooks/usePosts.ts
+- 🔴 **`:52-73`** — Create/edit/delete patch the cache via `updatePostsCache` but never `invalidateQueries`; the client diverges from server-computed fields. *Fix:* invalidate or use returned authoritative data.
+- 🟠 **`:44-50`** — Writes the tags cache from a `useEffect` via `setQueryData` — writing one query from another's render side-effect; races with `useTags`. *Fix:* `select`/derived query.
+- 🟠 **`:52-73`** — No `onError`/rollback on any mutation; errors aren't returned (only `isMutating`). *Fix:* error handling/state.
+- 🟡 **`:82-93,21-30`** — Unmemoized thin async wrappers; inconsistent return (`addPost` returns post, `editPost` discards); redundant `[...prev]` copy.
+
+### hooks/useTags.ts
+- 🟠 **`:18-31`** — `useTags` (`queryFn`+`ensureQueryData`) and `usePosts` (`setQueryData` in an effect) both own `POST_TAGS_QUERY_KEY` and race depending on mount order. *Fix:* one owner.
+- 🟡 **`:30`** — `staleTime: 1000*60` duplicated with `usePosts.ts:41`.
+
+### hooks/usePostFilters.ts
+- 🟠 **`:42-56`** — Lower-cases every searched field per filter per post inside nested loops → O(posts×filters×fields) allocations. *Fix:* precompute lowercased fields once.
+- 🟡 **`:60,118-119,136`** — `Map` used only for `.has()` (use a `Set`); tag-detection `startsWith('#')` duplicated; raw vs normalized token equality inconsistent.
+
+### hooks/use-toast.ts
+- 🔴 **`:6`** — `TOAST_REMOVE_DELAY = 1000000` (~16.7 min) → dismissed toasts are effectively never removed from memory. *Fix:* a realistic value.
+- 🟠 **`:23,125-127`** — Module-level mutable singleton state (untestable, leaks across renders).
+- 🟡 **`:15-21,138,170-178`** — `actionTypes` object only used as a type (dead runtime + an eslint-disable); pointless rest-spread; O(n) listener cleanup.
+
+### hooks/use-mobile.tsx
+- 🟡 **`:9-14,6-18`** — Breakpoint duplicated (`max-width:767px` vs `innerWidth<768`); `boolean|undefined` coerced with `!!`, hiding the "unmeasured" state.
+
+---
+
+## API client & lib utils
+
+### lib/utils/fetch.ts
+- 🔴 **`:38-68`** 🛡️ — No `credentials: 'include'` anywhere; session/CSRF break cross-origin. *Fix:* add it.
+- 🔴 **`:25-34`** 🛡️ — `getCsrfToken` doesn't check `response.ok` and reads untyped `data.token`; caches `undefined` for an hour on failure. *Fix:* validate + refresh on 403.
+- 🟠 **`:9,29`** — Module-global `csrfTokenCache` with a hardcoded 1-hour TTL that may exceed server token lifetime → stale-token 403s. *Fix:* configurable TTL + 403 refresh.
+- 🟡 **`:64`** — `body as BodyInit` cast hides the union narrowing.
+
+### lib/api/posts.ts
+- 🔴 **`:46,58-61,115-121`** 🛡️ — Several `fetch`es bypass `getFetchOptions`/`credentials` and lack `response.ok` checks; the presign GET blindly `.json()`s and the S3 `PUT` isn't checked — a failed upload still proceeds to create the post. *Fix:* status checks everywhere.
+- 🔴 **`:13,36-42`** — `signedUrlCache` is an unbounded module-level `Map` (a second hidden cache that desyncs from TanStack Query). *Fix:* bound it or drop it.
+- 🟠 **`:199-208`** — `updatePost` returns `modified: new Date(...)` but `createPost`/`getPosts`/`transcribePost` don't, so `Post.modified` is sometimes a `Date`, sometimes a string — violates the declared type. *Fix:* normalize on every path.
+- 🟠 **`:124,131`** — Magic default `media_type: 'audio'` in two branches silently mislabels video/image. *Fix:* derive correctly.
+- 🟠 **`:201`** — `Object.fromEntries(Object.entries(data))` is a no-op clone. *Fix:* remove.
+- 🟡 **`:50-55,73,93-99,160-162`** — DOM coupling via `window.location.origin`; untyped `as { url: string }` cast; commented-out debug/Safari dead code.
+
+### lib/utils/audio.ts
+- 🔴 **`:47-54`** — Re-encoding via `MediaRecorder` + `setTimeout(duration*1000 + 100)` is real-time (takes as long as the clip) and truncates the tail if the buffer hasn't flushed. *Fix:* encode the decoded buffer directly.
+- 🟠 **`:10-15,28-43,51`** — `AudioContext` leaks if `decodeAudioData` rejects before the timeout; `MediaRecorder` has no `onerror` → the Promise can hang forever. *Fix:* close in `finally`, add `onerror`.
+- 🟡 **`:67-75,121`** — Hard-to-read nested ternary; implicit `any[]`.
+
+### lib/utils/media.ts
+- 🔴 **`:30,46`** 🛡️ — Module-level `console.log` + `MediaRecorder.isTypeSupported` run at **import time**, throwing in non-browser/test/SSR. *Fix:* lazy functions; drop logs.
+- 🟠 **`:29,45`** — `supportedVideoMimeType`/`supportedAudioMimeType` computed once at import and can be `undefined` with no fallback. *Fix:* lazy + handle empty.
+- 🟡 **`:54-87,47`** — Dead defensive try/catch around non-throwing parse; possibly-unused `mimeTypes` export.
+
+### lib/utils/browser.ts
+- 🟠 **`:43-52`** — `isSafari` via `userAgentData` returns true for any macOS non-Chrome browser (Firefox-on-Mac misreported). *Fix:* feature detection / UA fallback.
+- 🟡 **`:36`** — `/Macintosh/ && /iPad/` can never both be true (dead condition); pervasive brittle UA sniffing.
+
+### lib/utils/file.ts
+- 🟠 **`:6-18`** — `getFileExtension`'s `URL`-parse and fallback paths don't compose; a successful parse with no dot throws instead of using the fallback. *Fix:* one path-based parse.
+- 🟡 **`:17,30-46`** — Throwing on "no extension" forces callers into try/catch for a common case; ogg/webm MIME guesses may mislabel.
+
+### lib/utils/ui.ts
+- 🔴 **`:10`** — `document.getElementsByTagName('header')[0].clientHeight` throws if no `<header>` exists (no null check despite guarding `window`/`element` above). *Fix:* guard the lookup.
+- 🟡 **`:10`** — Magic `+ 16` header offset.
+
+### lib/utils/settings.ts
+- 🟠 **`:21-29`** — `getSettings` returns `JSON.parse(stored) as AppSettings` with no validation/merge; an older stored schema yields `undefined` for new keys. *Fix:* `{ ...defaultSettings, ...parsed }`.
+- 🟡 **`:11-19`** — Default `normalizeAudio` frozen at import via UA sniffing.
+
+### lib/constants.ts & utils/tags.ts & types/
+- 🟡 **`constants.ts:1-5`** — `import.meta.env.VITE_*` cast `as string` with no validation; missing host silently becomes `''`.
+- 🟡 **`utils/tags.ts:4,38-41`** — `HASHTAG_REGEX` excludes Unicode/emoji/hyphen tags (silently drops valid tags); display casing vs case-insensitive counting inconsistency. Also: two `utils` dirs (`src/utils` and `src/lib/utils`) — confusing structure.
+- 🟠 **`types/post.ts:26,32`** — `head`/`likes`/`Author.avatar` are required but carry `// TODO: Implement`; consumers handle values the backend may not populate. *Fix:* mark optional until implemented.
+- 🟡 **`types/post.ts:19-35`** — `created`/`modified` typed `Date` but the API returns ISO strings (only some paths convert); `signedMediaUrl` (client-injected) mixed into the server type — forces `as` casts. *Fix:* separate API DTO vs domain type.
+
+### lib/api/auth.ts
+- 🟠 **`:13-39`** — try/catch only `console.error`s then re-throws (double-logging, no recovery). *Fix:* enrich or drop.
+- 🟡 **`:18-19`** — Throws `JSON.stringify(errors)` as an `Error` message, forcing callers to `JSON.parse` it. *Fix:* typed error object. No `login` here despite the split module boundary.

--- a/reports/code-smells/04-tests-and-cross-cutting.md
+++ b/reports/code-smells/04-tests-and-cross-cutting.md
@@ -1,0 +1,78 @@
+# 04 — Tests & Cross-Cutting
+
+Test-quality findings plus codebase-wide patterns surfaced by targeted searches. Severities: 🔴 high · 🟠 medium · 🟡 low.
+
+---
+
+## Part 1 — Test quality
+
+### Stale frontend tests (assert against an obsolete model / pre-TanStack API)
+
+- 🔴 **`app/src/__tests__/data/mockPosts.ts:3-33`** — Mock uses a defunct `Post` shape (string `id`, `text`, `mediaType`, `mediaUrl`, `timestamp`, `username`, `userAvatar`, `likes`) vs the current numeric `id`, `head`/`body`, nested `author`/`media`, `created`/`modified`, `url`. Every consumer asserts an obsolete model. *Fix:* regenerate from the real `Post` interface.
+- 🔴 **`app/src/__tests__/lib/api/posts.test.ts:14-33,29,69`** — Asserts `getPosts` calls `'http://localhost:3000/api/posts'` (no trailing slash) and `createPost` POSTs JSON, but the real code calls `${SERVER_API_URL}/posts/` and builds `FormData`; the signed-URL fan-out and `created`→Date mapping are untested. *Fix:* rewrite against the current implementation.
+- 🔴 **`app/src/__tests__/hooks/usePosts.test.tsx:20-101`** — `renderHook(() => usePosts())` with **no `QueryClientProvider`**; the real hook is TanStack-Query-based and would throw. Uses raw `setTimeout` waits and a defunct return shape. *Fix:* wrap in a provider; use `waitFor`; assert the real surface.
+- 🔴 **`app/src/__tests__/components/Feed.test.tsx:9-99`** — Renders `<Feed/>` (which uses `usePosts()`) with no provider and over-mocks `post`/`create` modules so assertions only verify the stubs. *Fix:* provider + realistic render.
+- 🟡 **`app/src/__tests__/setup.ts:5` & `posts.test.ts:6`** — `global.fetch = vi.fn()` duplicated. *Fix:* keep only in setup.
+
+### Missing coverage
+
+- 🔴 **`server/apps/users/tests.py`** — No tests. The custom `User` model and the `init_users` command (superuser + the anonymous user ID=2 that anonymous posting depends on) are untested. *Fix:* test `init_users` idempotency + the anonymous-user invariant.
+- 🔴 **`server/apps/website/tests.py`** — No tests for the index route or the OG-metadata post-detail page `/p/<id>/` (a public path), incl. 404 for missing posts.
+- 🔴 **`server/apps/blogs/tests/test_views.py`** — No tests for the `transcribe` action, the media streaming endpoint (range requests — the Safari-critical path), or list/retrieve serialization. Only create/delete/update/permissions are covered.
+- 🟠 **`server/apps/auth/tests.py`** — Only signup. No `login` (success/bad creds), `logout`, `csrf`, or unauthenticated `status`.
+- 🟠 **`server/apps/blogs/tests/test_views.py:40-67`** — Nothing asserts anonymous POSTs are rejected/routed to the anonymous user, nor that `author == request.user` (a security-relevant binding).
+
+### Weak / brittle / assertion-free tests
+
+- 🟠 **`server/apps/blogs/tests/test_models.py:130-165`** — `test_media_duration_extraction_with_real_file` builds a 16-byte fake MP3 then asserts `assertIsInstance(media.duration, (type(None), timedelta))` — passes whether or not extraction works (effectively assertion-free). *Fix:* use a real generated file or delete.
+- 🟠 **`server/apps/blogs/tests/test_models.py:96-128`** — `test_media_duration_extraction` mostly asserts non-behavior ("doesn't crash", `assertIsNone` for a fake mp3). *Fix:* split and remove the no-op assertions.
+- 🟠 **`server/apps/blogs/tests/test_models.py:132,197,216`** — Unused `import subprocess`, repeated in-method `import tempfile`, ffmpeg-dependent tests that `skipTest` silently. *Fix:* hoist imports; gate ffmpeg behind a shared visible check.
+- 🟠 **Duplicated test setup** — `MediaModelTests`, `PostModelTests`, `PostViewSetTests` each recreate `testuser`/`test_file`/`test_mp3` and the same recursive media-cleanup teardown (4th copy in `ViewTestCase`). *Fix:* a shared base with fixtures + one cleanup helper.
+- 🟡 **`server/apps/blogs/tests/test_views.py:29-38,273-281`** — `self.temp_dir` setup/teardown that no test writes into; view tests also lack `@override_settings(MEDIA_ROOT=…)` (model tests have it) — confirm they aren't writing into the real `MEDIA_ROOT`.
+- 🟡 **`server/apps/blogs/tests/test_models.py:172-193`** — `..._skips_if_already_set` uses the fake mp3, so "skip" is indistinguishable from "returned None"; passes even if skip logic is removed.
+- 🟡 **`server/apps/auth/tests.py:64-86`** — `test_signup_weak_password` overrides `AUTH_PASSWORD_VALIDATORS` in-test, testing the override rather than the project's real validators.
+
+---
+
+## Part 2 — Cross-cutting patterns
+
+### Debug statements left in production
+
+- 🔴 **`server/apps/blogs/views.py:58-61,126`** — `print(...)` used for logging (the `:126` one ungated). *Fix:* `logger.debug`.
+- 🟠 **`app/src/lib/utils/media.ts:30,46`** — `console.log('INFO: ...')` at module import, every page load.
+- 🟠 **`app/src/components/post/create/AudioRecorder.tsx:144,148,160`** — amplitude/gain `console.log`s in the recorder.
+- 🟡 **`app/src/components/Feed.tsx:51`, `Profile.tsx:64,69`, `pages/NotFound.tsx:8`** — placeholder/stub `console.log`/`console.error`.
+- 🟡 **`app/src/lib/api/posts.ts:94-95`** — commented-out `console.log` block.
+
+### Broad exception handling (no bare `except:` found — all are `except Exception`)
+
+- 🟠 **`server/apps/blogs/models.py:67,79,86,93,100,137`** — six broad catches in file/media cleanup swallow real errors. *Fix:* narrow to `OSError`/`FileNotFoundError`.
+- 🟠 **`server/apps/blogs/views.py:163,244`** — broad catch in transcribe + range-parse (silent whole-file fallback). *Fix:* narrow the range-parse catch.
+- 🟡 **`server/apps/blogs/utils/get_file_mimetype.py:20`, `utils/media.py:31`** — broad catches in helpers. *Fix:* narrow.
+- 🟠 **Frontend (pervasive)** — `try { … } catch (e) { console.error(e); throw e }` in `auth.ts`, `posts.ts`, `audio.ts`, `media.ts`, `settings.ts` adds noise without recovery. *Fix:* centralize.
+
+### Duplicated constants / hardcoded values
+
+- 🔴 **Media-type union duplicated** — `server/apps/blogs/models.py:18-21` (`MEDIA_TYPE_CHOICES`) vs `app/src/types/post.ts:11,40` (twice). Can drift silently. *Fix:* one shared source; document/generate from backend choices.
+- 🟠 **`app/src/__tests__/lib/api/posts.test.ts:29,69`** — hardcoded `http://localhost:3000` doesn't match the runtime default (empty host → relative `/api`).
+- 🟠 **`server/config/settings.py:354-374,440-483`** — dev origins/ports repeated across CORS, CSRF, and CSP sections. *Fix:* one env-driven list.
+- 🟡 **"1 minute" cache duration triplicated** — `posts.ts:5` (`SIGNED_URL_CACHE_DURATION_MS = 60_000`), `usePosts.ts:40`/`useTags.ts:30` (`staleTime: 1000*60`), and the backend presign expiry. *Fix:* shared constant.
+- 🟠 **`ANONYMOUS_USER_ID = 2`** hardcoded in `blogs/views.py` and `uploads/views.py:28`. *Fix:* one setting.
+
+### Type-suppression comments
+
+- 🟠 **`server/apps/blogs/views.py:39,68-73,92-93,185-186,243-245`** — many per-line `# pyright: ignore [...]` around `request.user.id`, `serializer.instance`, range parsing — the type model isn't expressed. *Fix:* proper narrowing instead of blanket ignores.
+- 🟠 **`server/apps/blogs/tests/test_models.py:2`, `test_views.py:2`, `auth/tests.py:2`** — file-level `# pyright: reportAttributeAccessIssue=false` disables checking for whole files. *Fix:* targeted ignores.
+- 🟡 **`server/apps/blogs/serializers.py:10,16,36,50`, `admin.py:41,46`** — DRF/Django-stubs friction ignores. *Fix:* shared stub fix.
+- 🟡 **Frontend** — ~15 `eslint-disable`/`biome-ignore`, mostly vendored/justified. The `useExhaustiveDependencies` suppressions at `MediaPlayer.tsx:148,418` and `AudioRecorder.tsx:363` can hide stale-closure bugs — review.
+
+### TODO/FIXME backlog (informational)
+
+- 🟠 **`server/apps/blogs/views.py:201,217`** — "Restrict access to share only to authorized users" — a real auth gap, not just a comment (see [01-security.md](01-security.md)).
+- 🟡 Open TODOs flag known gaps: `views.py:26` (prefetch), `uploads/views.py:62,71` (signed-URL caching), `posts.ts:62` (N+1 presign), `types/post.ts:4,32` (`avatar`/`likes`), `Feed.tsx:50` (likes), `CreatePost.tsx:94` (audio/video detection), `convert_to_mp3.py:28` (file-exists collision).
+
+### Clean signals
+
+- No `: any` / `as any` / `@ts-ignore` / `@ts-nocheck` in app source.
+- No bare `except:` in Python.
+- Style conventions (single quotes, no semicolons, tab indent, line length) are followed — style was not a meaningful source of findings.

--- a/reports/code-smells/README.md
+++ b/reports/code-smells/README.md
@@ -1,0 +1,58 @@
+# Code Smell Report — webframework
+
+**Date:** 2026-05-29
+**Scope:** Full codebase — `server/` (Django, ~2,550 LOC) and `app/src/` (React/TypeScript, ~10,650 LOC), excluding generated migrations and vendored `shadcn/ui` primitives.
+**Method:** Six focused reviewers swept the code by area (backend core, backend infra/security, React post components, React app/pages, hooks/api/lib, tests/cross-cutting). Every finding carries a `file:line` reference and a one-line fix. The highest-severity security claims were manually spot-checked against source and confirmed.
+
+## How findings are organized
+
+| Report | Area | Findings |
+|---|---|---|
+| [01-security.md](01-security.md) | **Critical & high-severity security issues** (consolidated across the whole codebase) | 13 |
+| [02-backend.md](02-backend.md) | Django backend — models, views, serializers, utils, settings, auth, uploads, users, website | ~70 |
+| [03-frontend.md](03-frontend.md) | React — post components, app components, pages, hooks, API client, lib utils | ~120 |
+| [04-tests-and-cross-cutting.md](04-tests-and-cross-cutting.md) | Test quality + cross-cutting patterns (debug logging, broad excepts, duplicated constants, suppressions, TODOs) | ~40 |
+
+Security issues are listed in **01-security.md** for triage and also remain in their area report (02/03) with full context. Everything else lives only in its area report.
+
+## Severity at a glance
+
+| Severity | Count (approx.) | Meaning |
+|---|---|---|
+| 🔴 **High** | ~45 | Security exposure, data corruption/leak, resource leaks, false-success error handling, or broken-at-runtime code. Fix soon. |
+| 🟠 **Medium** | ~80 | Maintainability hazards, N+1 queries, duplicated logic, inconsistent typing, missing error UX. Fix opportunistically. |
+| 🟡 **Low** | ~90 | Style drift, magic numbers, dead code, minor inconsistency. Cleanup. |
+
+## Top 13 issues to fix first
+
+These are the highest-impact, independently verified problems. Full detail in [01-security.md](01-security.md) unless noted.
+
+1. **🔴 Presigned-URL endpoints have no authentication** — `server/apps/uploads/views.py:20,75`. Any anonymous caller can mint a presigned `PUT` URL (write to your bucket) or a presigned `GET` for any post's media.
+2. **🔴 Path traversal in S3 key construction** — `server/apps/uploads/views.py:28`. User-supplied `file_name` is concatenated straight into the object key with no sanitization (`../` escapes the prefix).
+3. **🔴 All uploaded media is world-readable** — `server/config/settings.py:391-392`. `AWS_DEFAULT_ACL='public-read'` + `AWS_QUERYSTRING_AUTH=False` makes every object public and its URL unauthenticated, defeating the presigned-URL model entirely.
+4. **🔴 Hardcoded `admin`/`admin` superuser** — `server/apps/users/management/commands/init_users.py:25`. The `--superuser-only` path creates a trivially guessable admin. The anonymous user is also created without `set_unusable_password()`.
+5. **🔴 Startup fabricates a fresh `SECRET_KEY`** — `server/config/settings.py:70-101`. A missing `.env` is silently auto-generated with a new key; in production this rotates the key per deploy (invalidating sessions/signatures) and hides misconfiguration. Fail fast instead.
+6. **🔴 Missing production security headers** — `server/config/settings.py`. No `SECURE_SSL_REDIRECT`, `SECURE_HSTS_SECONDS`, `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SECURE_PROXY_SSL_HEADER`, or `SECURE_CONTENT_TYPE_NOSNIFF`. Cookies can travel over HTTP.
+7. **🔴 XSS risk: regex re-injects user content after sanitization** — `app/src/components/post/Post.tsx:32-38`. `DOMPurify.sanitize()` runs first, then a regex splices the captured URL into raw anchor HTML rendered via `dangerouslySetInnerHTML`; the post-sanitize URL is not re-escaped. Sanitize the *final* HTML. (See [03-frontend.md](03-frontend.md).)
+8. **🔴 `credentials: 'include'` is missing on every fetch** — `app/src/lib/utils/fetch.ts:38-68`, `app/src/hooks/useAuth.tsx:30`, several calls in `app/src/lib/api/posts.ts`. Session-cookie auth + CSRF silently break when the API is cross-origin. (See [03-frontend.md](03-frontend.md).)
+9. **🔴 ffmpeg/transcode failures are swallowed and reported as success** — `server/apps/blogs/utils/convert_to_mp3.py:42-50`. `CalledProcessError` is logged but the function still returns the output path as if it succeeded; callers treat a non-existent file as valid. Mirrored in `get_file_mimetype.py` (returns `'unknown'`). (See [02-backend.md](02-backend.md).)
+10. **🔴 Object-URL / AudioContext / media-stream leaks** — `MediaPlayer.tsx:194-222,438-466`, `VideoRecorder.tsx:105-117`, `AudioRecorder.tsx:120-122`. `URL.createObjectURL` without `revokeObjectURL`, `new AudioContext()` never `close()`d, and `getUserMedia` tracks not stopped on unmount. (See [03-frontend.md](03-frontend.md).)
+11. **🔴 Event-listener leak from mismatched add/remove** — `app/src/components/feed/FilterControls.tsx:57-71`. The cleanup passes a *different* anonymous function to `removeEventListener`, so the `keyup` listener is never removed. Verified. (See [03-frontend.md](03-frontend.md).)
+12. **🔴 Unhandled `DoesNotExist` → 500 instead of 404; DRF objects returned from plain views** — `server/apps/blogs/views.py:200-300`. `Post.objects.get(...)` without `get_object_or_404`, `post.media.file` dereferenced without a null check, and `Response(...)`/`FileResponse(bytes)` misused in non-DRF views. (See [02-backend.md](02-backend.md).)
+13. **🔴 Mutations never invalidate the query cache** — `app/src/hooks/usePosts.ts:52-73`. Create/edit/delete patch the cache by hand but never `invalidateQueries`, so the client silently diverges from server-computed fields. (See [03-frontend.md](03-frontend.md).)
+
+## Recurring themes (worth a single systemic fix each)
+
+- **Silent error handling everywhere.** `try { … } catch (e) { console.error(e); throw e }` adds noise without recovery across `auth.ts`, `posts.ts`, `audio.ts`, `media.ts`, `settings.ts`; six broad `except Exception` blocks in `models.py` swallow file-cleanup errors. Centralize and narrow.
+- **Hand-rolled auth instead of the framework.** `PostViewSet` uses `AllowAny` + duplicated inline `is_author`/`is_admin` checks; auth views skip `@require_POST`/throttling. Use DRF permission classes + throttles.
+- **Duplicated logic ripe for extraction.** `formatTime` (3 copies, 2 formats), the "pause all other `<audio>`/`<video>`" DOM hack (3 copies), forged synthetic events (`{ preventDefault(){} } as React.FormEvent`, 4 copies), the auth-modal scaffold (Login/Signup), the page-shell layout (3 copies), and the whole audio-player in `MediaPreview` duplicating `MediaPlayer`.
+- **Media-type union duplicated across the stack.** `'audio'|'video'|'image'` is defined in `models.py` and twice in `types/post.ts` with no shared source of truth.
+- **N+1 queries.** `PostViewSet.queryset`, `PostAdmin.list_display`, and `PostSerializer`'s reverse relations all lack `select_related`/`prefetch_related`.
+- **Dead / stub code shipping to users.** `Profile.tsx` is entirely mock data with stub handlers; `AudioPostTab`/`VideoPostTab`/`TextPostTab` appear unreferenced; `auth/models.py` and `users/views.py` are empty boilerplate; commented-out blocks in `settings.py` and `posts.ts`.
+- **Stale tests.** Multiple frontend test files (`posts.test.ts`, `usePosts.test.tsx`, `Feed.test.tsx`, `mockPosts.ts`) assert against an obsolete `Post` shape / pre-TanStack-Query API and cannot reflect current behavior; `users`, `website`, transcription, and media-streaming have no coverage.
+
+## Notes on what's clean
+
+- No `: any` / `as any` / `@ts-ignore` in app source (good TS discipline; the typing gaps are untyped `await response.json()` results, not explicit `any`).
+- No bare `except:` in Python (all are `except Exception as e`).
+- Reviewed files follow repo style conventions (single quotes, no semicolons, tab indent on the frontend; line length on the backend). Style was **not** a significant source of findings — the issues are substantive.


### PR DESCRIPTION
## Summary

Adds a thorough code-smell audit of the full codebase (`server/` + `app/src/`) under `reports/code-smells/`. No code behavior changes — documentation only.

Each area was reviewed against correctness, security, maintainability, and the project's stated conventions. **~215 findings total (~64 high severity)**, each with a `file:line` reference and a suggested one-line fix. The highest-severity security claims were manually verified against source.

## Report structure

| File | Contents |
|---|---|
| `README.md` | Executive summary, severity tally, top 13 issues, recurring themes |
| `01-security.md` | 13 critical/high security findings, consolidated for triage |
| `02-backend.md` | ~70 Django findings by file (21 high) |
| `03-frontend.md` | ~120 React/TS findings by file (30 high) |
| `04-tests-and-cross-cutting.md` | Test quality, missing coverage, and cross-cutting patterns (10 high) |

## Headline issues

- **Open object storage** — `public-read` ACL + `AWS_QUERYSTRING_AUTH=False`, presigned-URL endpoints with no auth, and path traversal in the S3 key from unsanitized `file_name`.
- **Secrets/hardening** — startup fabricates a fresh `SECRET_KEY`, hardcoded `admin/admin` superuser, missing production SSL/cookie/HSTS headers.
- **Frontend correctness/leaks** — post-sanitize regex re-injection in `Post.tsx`, missing `credentials: 'include'` on every fetch, object-URL / `AudioContext` / mic-stream leaks, an event-listener leak, and mutations that never invalidate the query cache.
- **Systemic** — pervasive `catch → log → rethrow`, hand-rolled auth instead of DRF permissions, N+1 queries, heavily duplicated logic, and stale tests asserting an obsolete `Post` shape.

## Notes

- This is a **draft** for review/triage — findings are recommendations, not yet acted on.
- Clean signals worth noting: no `any`/`@ts-ignore` in app code, no bare `except:`, and style conventions are consistently followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)